### PR TITLE
Implementando tratamento de erros personalizados

### DIFF
--- a/backend/src/main/java/br/com/fecaf/exception/custom/DuplicateCpfException.java
+++ b/backend/src/main/java/br/com/fecaf/exception/custom/DuplicateCpfException.java
@@ -1,0 +1,7 @@
+package br.com.fecaf.exception.custom;
+
+public class DuplicateCpfException extends RuntimeException {
+    public DuplicateCpfException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/br/com/fecaf/exception/custom/DuplicateEmailException.java
+++ b/backend/src/main/java/br/com/fecaf/exception/custom/DuplicateEmailException.java
@@ -1,0 +1,7 @@
+package br.com.fecaf.exception.custom;
+
+public class DuplicateEmailException extends RuntimeException {
+    public DuplicateEmailException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/br/com/fecaf/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/br/com/fecaf/exception/handler/GlobalExceptionHandler.java
@@ -1,4 +1,39 @@
 package br.com.fecaf.exception.handler;
 
+import br.com.fecaf.exception.custom.DuplicateCpfException;
+import br.com.fecaf.exception.custom.DuplicateEmailException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private Map<String, Object> buildBody(HttpStatus status, String error, Object message) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", status.value());
+        body.put("error", error);
+        body.put("message", message);
+        return body;
+    }
+
+
+    @ExceptionHandler(DuplicateCpfException.class)
+    public ResponseEntity<Object> handleDuplicateCpf(DuplicateCpfException ex) {
+        Map<String, Object> body = buildBody(HttpStatus.CONFLICT, "Bad Request", ex.getMessage());
+        return new ResponseEntity<>(body, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(DuplicateEmailException.class)
+    public ResponseEntity<Object> handleDuplicateEmail(DuplicateEmailException ex) {
+        Map<String, Object> body = buildBody(HttpStatus.CONFLICT, "Bad Request", ex.getMessage());
+        return new ResponseEntity<>(body, HttpStatus.CONFLICT);
+    }
+
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -2,8 +2,8 @@
 
 #OBS > UTILIZAR O USUARIO E A SENHA DO SEU DB
 spring.datasource.url=jdbc:mysql://localhost:3306/db_automotivo
-spring.datasource.username=
-spring.datasource.password=
+spring.datasource.username= root
+spring.datasource.password= pamela21
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Configuração do JPA


### PR DESCRIPTION
Este PR introduz o tratamento global de exceções na API, focando inicialmente nas regras de negócio para o cadastro de usuários. Através da anotação @RestControllerAdvice, as exceções lançadas na camada de serviço são capturadas e transformadas em uma resposta JSON padronizada