### PR TITLE
feature/0004/implementando-senha-hash-task

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -67,6 +67,11 @@
             <version>0.2.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/backend/src/main/java/br/com/fecaf/config/SecurityConfig.java
+++ b/backend/src/main/java/br/com/fecaf/config/SecurityConfig.java
@@ -1,4 +1,31 @@
 package br.com.fecaf.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/v1/users").permitAll()
+                        .anyRequest().authenticated()
+                );
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }

--- a/backend/src/main/java/br/com/fecaf/service/UserService.java
+++ b/backend/src/main/java/br/com/fecaf/service/UserService.java
@@ -7,14 +7,18 @@ import br.com.fecaf.mapper.UserMapper;
 import br.com.fecaf.model.User;
 import br.com.fecaf.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
     private final UserMapper userMapper;
+    private final PasswordEncoder passwordEncoder;
 
     public UserDTO registerUser(UserDTO userDTO) {
 
@@ -28,10 +32,12 @@ public class UserService {
             throw new DuplicateCpfException();
         }
 
-        user.setPasswordHash(userDTO.password());
+        String encryptedPassword = passwordEncoder.encode(userDTO.password());
+        user.setPasswordHash(encryptedPassword);
+        log.debug("User registered successfully: {}", user.getEmail());
 
-        User savedUser = userRepository.save(user);
+        user = userRepository.save(user);
 
-        return userMapper.toDTO(savedUser);
+        return userMapper.toDTO(user);
     }
 }


### PR DESCRIPTION
Implementa a criptografia de senha no cadastro de usuários utilizando BCryptPasswordEncoder do Spring Security.

A senha passa a ser tratada na camada de serviço antes de ser persistida, garantindo que não seja armazenada em texto puro no banco de dados.