### PR TITLE
implementacao do docker no projeto

### DIFF
--- a/backend/.idea/compiler.xml
+++ b/backend/.idea/compiler.xml
@@ -16,6 +16,10 @@
           <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct/1.5.5.Final/mapstruct-1.5.5.Final.jar" />
           <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/1.18.32/lombok-1.18.32.jar" />
           <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok-mapstruct-binding/0.2.0/lombok-mapstruct-binding-0.2.0.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct-processor/1.5.5.Final/mapstruct-processor-1.5.5.Final.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct/1.5.5.Final/mapstruct-1.5.5.Final.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/1.18.32/lombok-1.18.32.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok-mapstruct-binding/0.2.0/lombok-mapstruct-binding-0.2.0.jar" />
         </processorPath>
         <module name="Sistema-Automotivo" />
       </profile>

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,16 @@
+# Estágio 1: Build (Gera o arquivo .jar)
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+WORKDIR /app
+
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# Estágio 2: Execução (Roda a aplicação)
+FROM eclipse-temurin:21-jre-jammy
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  app:
+    build: .
+    container_name: api-automotiva
+    ports:
+      - "8080:8080"
+    environment:
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - JWT_SECRET=${JWT_SECRET}
+      - SPRING_DATASOURCE_URL=jdbc:mysql://db:3306/db_automotivo?createDatabaseIfNotExist=true
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: mysql:8.0
+    container_name: mysql-db
+    restart: always
+    ports:
+      - "3307:3306"
+    environment:
+      - MYSQL_DATABASE=db_automotivo
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -12,7 +12,8 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.7</version>
+        <version>3.4.0</version>
+        <relativePath/>
     </parent>
 
     <properties>
@@ -21,7 +22,6 @@
     </properties>
 
     <dependencies>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -89,13 +89,10 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>
         <plugins>
-
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -104,30 +101,37 @@
                     <source>21</source>
                     <target>21</target>
                     <annotationProcessorPaths>
-
                         <path>
                             <groupId>org.mapstruct</groupId>
                             <artifactId>mapstruct-processor</artifactId>
                             <version>1.5.5.Final</version>
                         </path>
-
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
                             <version>1.18.32</version>
                         </path>
-
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok-mapstruct-binding</artifactId>
                             <version>0.2.0</version>
                         </path>
-
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/backend/src/main/java/br/com/fecaf/config/SecurityConfig.java
+++ b/backend/src/main/java/br/com/fecaf/config/SecurityConfig.java
@@ -29,12 +29,15 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/v3/api-docs",
                                 "/v3/api-docs/**",
                                 "/v3/api-docs.yaml",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/swagger-resources/**",
-                                "/webjars/**"
+                                "/webjars/**",
+                                "/configuration/ui",
+                                "/configuration/security"
                         ).permitAll()
 
                         .requestMatchers(HttpMethod.GET, "/v1/users").hasRole("ADMIN")

--- a/backend/src/main/java/br/com/fecaf/config/SeedConfig.java
+++ b/backend/src/main/java/br/com/fecaf/config/SeedConfig.java
@@ -28,6 +28,7 @@ public class SeedConfig {
                     .orElseGet(() -> {
                         Role role = new Role();
                         role.setName("ADMIN");
+                        role.setDescription("Acesso total de administrador");
                         return roleRepository.save(role);
                     });
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/db_automotivo
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/db_automotivo}
 spring.datasource.username=${DB_USER:root}
 spring.datasource.password=${DB_PASSWORD:root}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
Este PR implementa o suporte a containers na aplicação, permitindo que todo o ambiente (API + Banco de Dados) suba com um único comando.

**O que foi feito:**
1. Dockerfile: Criado para empacotar a aplicação Spring Boot utilizando a JDK 17 (ou a versão que você usou).

2. Docker Compose: Configurado para orquestrar dois serviços: api-automotiva e db-mysql.

3. Variáveis de Ambiente: Centralização das configurações sensíveis (usuário, senha do banco e segredo do JWT) no docker-compose.

4. Rede Interna: Ajuste na string de conexão do banco para utilizar o nome do serviço do container em vez de localhost.

**Como testar:**
1. Certifique-se de ter o Docker e Docker Compose instalados.

2. No terminal, execute: **docker-compose up --build.**

3. Aguarde os logs confirmarem a conexão com o banco e a inicialização da API.
 
4. Teste o acesso via Swagger: **http://localhost:8080/swagger-ui/index.html.**